### PR TITLE
feat: add period option and deprecate month option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,52 +1,66 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+# Use system Python to avoid venv issues with Python 3.13
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
-      - id: check-toml
-      - id: check-merge-conflict
-      - id: debug-statements
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
-    hooks:
-      - id: pyupgrade
-        args: [--py310-plus]
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
-  - repo: https://github.com/psf/black
-    rev: 25.12.0
-    hooks:
-      - id: black
-        language_version: python3.10
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.3.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-black
-          - flake8-docstrings
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
-    hooks:
-      - id: mypy
-        additional_dependencies: [types-PyYAML]
-        args: [--ignore-missing-imports]
-
   - repo: local
     hooks:
+      - id: trailing-whitespace
+        name: trailing-whitespace
+        entry: poetry run trailing-whitespace-fixer
+        language: system
+        types: [text]
+
+      - id: end-of-file-fixer
+        name: end-of-file-fixer
+        entry: poetry run end-of-file-fixer
+        language: system
+        types: [text]
+
+      - id: check-yaml
+        name: check-yaml
+        entry: poetry run python -c "import yaml; [yaml.safe_load(open(f)) for f in __import__('sys').argv[1:]]"
+        language: system
+        types: [yaml]
+        pass_filenames: true
+
+      - id: check-toml
+        name: check-toml
+        entry: poetry run python -c "import tomllib; [tomllib.load(open(f, 'rb')) for f in __import__('sys').argv[1:]]"
+        language: system
+        types: [toml]
+        pass_filenames: true
+
+      - id: pyupgrade
+        name: pyupgrade
+        entry: poetry run pyupgrade --py310-plus
+        language: system
+        types: [python]
+
+      - id: isort
+        name: isort
+        entry: poetry run isort --profile black
+        language: system
+        types: [python]
+
+      - id: black
+        name: black
+        entry: poetry run black --check --diff
+        language: system
+        types: [python]
+
+      - id: flake8
+        name: flake8
+        entry: poetry run flake8
+        language: system
+        types: [python]
+
+      - id: mypy
+        name: mypy
+        entry: poetry run mypy --ignore-missing-imports src/
+        language: system
+        types: [python]
+        pass_filenames: false
+
       - id: pytest
         name: pytest
         stages: [pre-commit]

--- a/completions/pacioli-complete.bash
+++ b/completions/pacioli-complete.bash
@@ -26,4 +26,3 @@ _pacioli_completion_setup() {
 }
 
 _pacioli_completion_setup;
-

--- a/completions/pacioli-complete.zsh
+++ b/completions/pacioli-complete.zsh
@@ -32,4 +32,3 @@ _pacioli_completion() {
 }
 
 compdef _pacioli_completion pacioli;
-

--- a/man/pacioli.1
+++ b/man/pacioli.1
@@ -31,13 +31,13 @@ Run a balance sheet report using the account mappings defined in the config file
 .B pacioli
 balance-sheet
 [\fB\-e\fR \fIDATE\fR]
-\fIOUT_FILE\fR
+[\fIOUT_FILE\fR]
 .PP
 .B Arguments:
 .RS
 .TP
 .I OUT_FILE
-Path to write the LaTeX file. Use '\fB-\fR' to print to standard output.
+Path to write the LaTeX file. Defaults to standard output if not specified. Use '\fB-\fR' for explicit stdout.
 .RE
 .PP
 .B Options:
@@ -54,13 +54,14 @@ income-statement
 [\fB\-b\fR \fIDATE\fR]
 [\fB\-e\fR \fIDATE\fR]
 [\fB\-m\fR \fIMONTH\fR]
-\fIOUT_FILE\fR
+[\fB\-p\fR \fIPERIOD\fR]
+[\fIOUT_FILE\fR]
 .PP
 .B Arguments:
 .RS
 .TP
 .I OUT_FILE
-Path to write the LaTeX file. Use '\fB-\fR' to print to standard output.
+Path to write the LaTeX file. Defaults to standard output if not specified. Use '\fB-\fR' for explicit stdout.
 .RE
 .PP
 .B Options:
@@ -73,11 +74,30 @@ Start date for transactions.
 Limit the report to transactions before the specified date.
 .TP
 .BR \-m ", " \-\-month " " \fIMONTH\fR
-Limit report to a specific month. When specified, overrides begin-date and end-date.
+.B (DEPRECATED)
+Use --period instead. Limit report to a specific month. When specified, overrides begin-date and end-date.
+.TP
+.BR \-p ", " \-\-period " " \fIPERIOD\fR
+Specify a time period using natural language. When specified, overrides all other date options. Supported formats:
+.RS
+.IP \(bu 3
+\fBlast month\fR, \fBthis month\fR
+.IP \(bu 3
+\fBJan to Mar\fR (month ranges without year - uses current year for end date, handles year rollovers automatically)
+.IP \(bu 3
+\fBJan 2024 to Mar 2024\fR (month ranges with explicit years, full or abbreviated names)
+.IP \(bu 3
+\fBJanuary 2024\fR (single month with year)
+.IP \(bu 3
+\fB2024/01/15 to 2024/03/31\fR (explicit date ranges)
+.RE
+.PP
+.B Note on year rollovers:
+When using month ranges without years (e.g., \fBDec to January\fR), the current year is used for the end month. If the end month comes before the start month, the start month uses the previous year. For example, running \fBDec to January\fR in January 2026 gives December 2025 to January 2026.
 .RE
 .PP
 .B Note:
-At least one of --begin-date/--end-date or --month must be specified.
+At least one of --begin-date/--end-date, --month, or --period must be specified.
 .SS "cash-flow-statement"
 Run a cash flow statement for a set time period using the direct method. Generates a cash-basis report of inflows and outflows.
 .PP
@@ -86,13 +106,14 @@ cash-flow-statement
 [\fB\-b\fR \fIDATE\fR]
 [\fB\-e\fR \fIDATE\fR]
 [\fB\-m\fR \fIMONTH\fR]
-\fIOUT_FILE\fR
+[\fB\-p\fR \fIPERIOD\fR]
+[\fIOUT_FILE\fR]
 .PP
 .B Arguments:
 .RS
 .TP
 .I OUT_FILE
-Path to write the LaTeX file. Use '\fB-\fR' to print to standard output.
+Path to write the LaTeX file. Defaults to standard output if not specified. Use '\fB-\fR' for explicit stdout.
 .RE
 .PP
 .B Options:
@@ -105,11 +126,15 @@ Start date for transactions.
 Limit the report to transactions before the specified date.
 .TP
 .BR \-m ", " \-\-month " " \fIMONTH\fR
-Limit report to a specific month. When specified, overrides begin-date and end-date.
+.B (DEPRECATED)
+Use --period instead. Limit report to a specific month. When specified, overrides begin-date and end-date.
+.TP
+.BR \-p ", " \-\-period " " \fIPERIOD\fR
+Specify a time period using natural language. When specified, overrides all other date options. See income-statement command for supported period formats.
 .RE
 .PP
 .B Note:
-At least one of --begin-date/--end-date or --month must be specified.
+At least one of --begin-date/--end-date, --month, or --period must be specified.
 .PP
 The cash flow statement uses the \fBdirect method\fR and leverages Ledger's \fB--related\fR flag to ensure only cash-basis transactions are included. This means credit card purchases (liabilities) are excluded, and only transactions that directly affect cash accounts are included. The statement reconciles: Beginning Cash + Net Change = Ending Cash.
 .PP
@@ -279,7 +304,7 @@ pacioli balance-sheet -e 2024-12-31 balance_sheet.tex
 Generate an income statement for a specific month:
 .RS
 .nf
-pacioli income-statement -m January balance_sheet.tex income.tex
+pacioli income-statement -m January income.tex
 .fi
 .RE
 .PP
@@ -287,6 +312,34 @@ Generate an income statement for a date range:
 .RS
 .nf
 pacioli income-statement -b 2024-01-01 -e 2024-12-31 income.tex
+.fi
+.RE
+.PP
+Generate an income statement for last month using natural language:
+.RS
+.nf
+pacioli income-statement --period "last month" income.tex
+.fi
+.RE
+.PP
+Generate an income statement for Q1 of current year:
+.RS
+.nf
+pacioli income-statement --period "Jan to Mar" income.tex
+.fi
+.RE
+.PP
+Generate a cash flow statement for Q1 2024:
+.RS
+.nf
+pacioli cash-flow-statement --period "Jan 2024 to Mar 2024" cashflow.tex
+.fi
+.RE
+.PP
+Generate a report spanning year end (Dec 2025 to Jan 2026):
+.RS
+.nf
+pacioli income-statement --period "Dec to January" income.tex
 .fi
 .RE
 .PP

--- a/poetry.lock
+++ b/poetry.lock
@@ -405,6 +405,22 @@ files = [
 ]
 
 [[package]]
+name = "isort"
+version = "7.0.0"
+description = "A Python utility / library to sort Python imports."
+optional = false
+python-versions = ">=3.10.0"
+groups = ["dev"]
+files = [
+    {file = "isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1"},
+    {file = "isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187"},
+]
+
+[package.extras]
+colors = ["colorama"]
+plugins = ["setuptools"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
@@ -787,6 +803,22 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "pre-commit-hooks"
+version = "6.0.0"
+description = "Some out-of-the-box hooks for pre-commit."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pre_commit_hooks-6.0.0-py2.py3-none-any.whl", hash = "sha256:76161b76d321d2f8ee2a8e0b84c30ee8443e01376121fd1c90851e33e3bd7ee2"},
+    {file = "pre_commit_hooks-6.0.0.tar.gz", hash = "sha256:76d8370c006f5026cdd638a397a678d26dda735a3c88137e05885a020f824034"},
+]
+
+[package.dependencies]
+"ruamel.yaml" = ">=0.15"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 description = "Python style guide checker"
@@ -900,6 +932,21 @@ pytest = ">=7"
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pyupgrade"
+version = "3.21.2"
+description = "A tool to automatically upgrade syntax for newer versions."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pyupgrade-3.21.2-py2.py3-none-any.whl", hash = "sha256:2ac7b95cbd176475041e4dfe8ef81298bd4654a244f957167bd68af37d52be9f"},
+    {file = "pyupgrade-3.21.2.tar.gz", hash = "sha256:1a361bea39deda78d1460f65d9dd548d3a36ff8171d2482298539b9dc11c9c06"},
+]
+
+[package.dependencies]
+tokenize-rt = ">=6.1.0"
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -983,6 +1030,37 @@ files = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.0"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "ruamel_yaml-0.19.0-py3-none-any.whl", hash = "sha256:96ea8bafd9f3fdb0181ce3cc05e6ec02ce0a8788cbafa9b5a6e47c76fe26dfc6"},
+    {file = "ruamel_yaml-0.19.0.tar.gz", hash = "sha256:ff19233e1eb3e9301e7a3d437847713e361a80faace167639327efbe8c0e5f95"},
+]
+
+[package.dependencies]
+"ruamel.yaml.clibz" = {version = ">=0.3.3", markers = "platform_python_implementation == \"CPython\""}
+
+[package.extras]
+docs = ["mercurial (>5.7)", "ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel-yaml-clibz"
+version = "0.3.4"
+description = "C version of reader, parser and emitter for ruamel.yaml, compiled with Zig, derived from libyaml"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+markers = "platform_python_implementation == \"CPython\""
+files = [
+    {file = "ruamel_yaml_clibz-0.3.4.tar.gz", hash = "sha256:e99077ac6aa4943af1000161a0cb793a379c5c8cd03ea8dd3803e0b58739b685"},
+]
+
+[[package]]
 name = "setuptools"
 version = "67.6.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1009,6 +1087,18 @@ groups = ["dev"]
 files = [
     {file = "snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064"},
     {file = "snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895"},
+]
+
+[[package]]
+name = "tokenize-rt"
+version = "6.2.0"
+description = "A wrapper around the stdlib `tokenize` which roundtrips."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "tokenize_rt-6.2.0-py2.py3-none-any.whl", hash = "sha256:a152bf4f249c847a66497a4a95f63376ed68ac6abf092a2f7cfb29d044ecff44"},
+    {file = "tokenize_rt-6.2.0.tar.gz", hash = "sha256:8439c042b330c553fdbe1758e4a05c0ed460dbbbb24a606f11f0dee75da4cad6"},
 ]
 
 [[package]]
@@ -1145,4 +1235,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "d23f28766200ca9d3b453dffdbf793ab755eb0671c6204004a421b6b0be44ca5"
+content-hash = "6de5af4849fc6102100651581763326edd78f61d7de3e0024626102517d47223"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pacioli"
-version = "1.1.0"
+version = "1.2.0"
 description = "Beautiful report creation for plain text accounting"
 authors = [
     {name = "Jason Paris", email = "paris3200@gmail.com"}
@@ -72,6 +72,9 @@ nox-poetry = "^1.0.3"
 types-PyYAML = "^6.0.12"
 mypy = "^1.13.0"
 black = "^24.10.0"
+pyupgrade = "^3.21.2"
+isort = "^7.0.0"
+pre-commit-hooks = "^6.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/pacioli/__init__.py
+++ b/src/pacioli/__init__.py
@@ -1,3 +1,3 @@
 """Pacioli Package."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/src/pacioli/balance_sheet.py
+++ b/src/pacioli/balance_sheet.py
@@ -56,13 +56,12 @@ class BalanceSheet(Pacioli):
             )
         )
 
-        total_assets = (
-            current_assets["current_assets_total"] + longterm_assets["longterm_assets_total"]
+        total_assets = current_assets.get("current_assets_total", 0) + longterm_assets.get(
+            "longterm_assets_total", 0
         )
-        total_liabilities = (
-            secured_liabilities["secured_liabilities_total"]
-            + unsecured_liabilities["unsecured_liabilities_total"]
-        )
+        total_liabilities = secured_liabilities.get(
+            "secured_liabilities_total", 0
+        ) + unsecured_liabilities.get("unsecured_liabilities_total", 0)
         total_equity = total_assets - total_liabilities
         total_liabilities_equity = total_liabilities + total_equity
         ledger = {

--- a/src/pacioli/balance_sheet.py
+++ b/src/pacioli/balance_sheet.py
@@ -1,8 +1,7 @@
 from typing import Dict
 
 from pacioli.pacioli import Pacioli
-from pacioli.utils import format_balance
-from pacioli.utils import reverse_sign
+from pacioli.utils import format_balance, reverse_sign
 
 
 class BalanceSheet(Pacioli):
@@ -82,7 +81,7 @@ class BalanceSheet(Pacioli):
 
         return self.render_template(self.template, format_balance(ledger))
 
-    def process_accounts(self, category, category_name, date) -> Dict[(str, int)]:
+    def process_accounts(self, category, category_name, date) -> dict[(str, int)]:
         """Process account names and balances.
 
         Returns a dictionary of account short names and their corresponding balances

--- a/src/pacioli/cash_flow_statement.py
+++ b/src/pacioli/cash_flow_statement.py
@@ -8,8 +8,7 @@ CashFlowStatement
 
 from typing import Dict
 
-from pacioli.pacioli import logging
-from pacioli.pacioli import Pacioli
+from pacioli.pacioli import Pacioli, logging
 from pacioli.utils import format_balance
 
 
@@ -115,7 +114,7 @@ class CashFlowStatement(Pacioli):
             total += self.get_balance(account, date)
         return total
 
-    def process_accounts(self, category, start_date, end_date) -> Dict[str, int]:
+    def process_accounts(self, category, start_date, end_date) -> dict[str, int]:
         """Process account cash flow changes within time period.
 
         Uses Ledger's --related flag to get only cash-basis transactions.
@@ -156,10 +155,10 @@ class CashFlowStatement(Pacioli):
         for cash_account in self.config.cash_accounts:
             ledger_command.append(cash_account)
 
-        if self.effective is not None:
-            ledger_command.append(self.effective)
-        if self.cleared is not None:
-            ledger_command.append(self.cleared)
+        if self.effective:
+            ledger_command.append("--effective")
+        if self.cleared:
+            ledger_command.append("--cleared")
         if self.market:
             ledger_command.extend(self.market.split())
 

--- a/src/pacioli/cash_flow_statement.py
+++ b/src/pacioli/cash_flow_statement.py
@@ -63,16 +63,23 @@ class CashFlowStatement(Pacioli):
 
         # Process activity categories
         operating = self.process_accounts(self.config.operating_activities, start_date, end_date)
-        result["operating_activities_total"] = operating.pop("category_total")
+        result["operating_activities_total"] = operating.pop("category_total", 0)
         result["operating_activities"] = operating
 
         investing = self.process_accounts(self.config.investing_activities, start_date, end_date)
-        result["investing_activities_total"] = investing.pop("category_total")
+        result["investing_activities_total"] = investing.pop("category_total", 0)
         result["investing_activities"] = investing
 
         financing = self.process_accounts(self.config.financing_activities, start_date, end_date)
-        result["financing_activities_total"] = financing.pop("category_total")
+        result["financing_activities_total"] = financing.pop("category_total", 0)
         result["financing_activities"] = financing
+
+        if result["operating_activities_total"] == 0 and not operating:
+            logging.warning("No operating activities found for the specified period")
+        if result["investing_activities_total"] == 0 and not investing:
+            logging.warning("No investing activities found for the specified period")
+        if result["financing_activities_total"] == 0 and not financing:
+            logging.warning("No financing activities found for the specified period")
 
         # Calculate totals
         result["net_change_in_cash"] = (

--- a/src/pacioli/cli.py
+++ b/src/pacioli/cli.py
@@ -1,9 +1,10 @@
 import click
+
 from pacioli import __version__
 from pacioli.balance_sheet import BalanceSheet
 from pacioli.cash_flow_statement import CashFlowStatement
 from pacioli.income_statement import IncomeStatement
-from pacioli.utils import month_to_dates
+from pacioli.utils import month_to_dates, period_to_dates
 
 
 @click.group()
@@ -27,15 +28,15 @@ def cli(ctx, config) -> None:
 
 
 @cli.command()
-@click.argument("out-file", type=click.Path(allow_dash=True))
+@click.argument("out-file", type=click.Path(allow_dash=True), default="-")
 @click.option("--end-date", "-e", default="", help="Limit the report to transactions before date.")
 @click.pass_context
 def balance_sheet(ctx, out_file, end_date) -> None:
     """
     Run a balance report using the  account mappings defined in the config file.
 
-    OUT_FILE is the path to the file to write the tex file.  Use '-' to print
-    to standard output.
+    OUT_FILE is the path to the file to write the tex file. Defaults to standard
+    output if not specified. Use '-' for explicit stdout.
     """
     balance_sheet = ctx.obj["balance_sheet"]
 
@@ -49,21 +50,35 @@ def balance_sheet(ctx, out_file, end_date) -> None:
 @cli.command()
 @click.option("--begin-date", "-b", default="", help="Start date for transactions.")
 @click.option("--end-date", "-e", default="", help="Limit the report to transactions BEFORE date.")
-@click.option("--month", "-m", default="", help="Limit report to month.")
-@click.argument("out-file", type=click.Path(allow_dash=True))
+@click.option(
+    "--month", "-m", default="", help="(DEPRECATED: use --period instead) Limit report to month."
+)
+@click.option(
+    "--period",
+    "-p",
+    default="",
+    help="Period description (e.g., 'last month', 'Jan to Mar', 'Jan 2024 to Mar 2024').",
+)
+@click.argument("out-file", type=click.Path(allow_dash=True), default="-")
 @click.pass_context
-def income_statement(ctx, begin_date, end_date, month, out_file) -> None:
+def income_statement(ctx, begin_date, end_date, month, period, out_file) -> None:
     """
     Run a income statement for a set time period.
 
-    OUT_FILE is the path to the file to write the tex file.  Use '-' to print
-    to standard output.
+    OUT_FILE is the path to the file to write the tex file. Defaults to standard
+    output if not specified. Use '-' for explicit stdout.
     """
     income_statement = ctx.obj["income_statement"]
 
-    if begin_date == end_date == month == "":
-        raise click.UsageError("Please enter a valid begin-date and end-date or a valid month.")
+    if begin_date == end_date == month == period == "":
+        raise click.UsageError("Please enter a valid begin-date and end-date, month, or period.")
+    elif period != "":
+        begin_date, end_date = period_to_dates(period)
     elif month != "":
+        click.echo(
+            "Warning: --month is deprecated. Use --period instead (e.g., --period 'January').",
+            err=True,
+        )
         begin_date, end_date = month_to_dates(month)
 
     report = income_statement.print_report(begin_date, end_date)
@@ -77,21 +92,35 @@ def income_statement(ctx, begin_date, end_date, month, out_file) -> None:
 @cli.command()
 @click.option("--begin-date", "-b", default="", help="Start date for transactions.")
 @click.option("--end-date", "-e", default="", help="Limit the report to transactions BEFORE date.")
-@click.option("--month", "-m", default="", help="Limit report to month.")
-@click.argument("out-file", type=click.Path(allow_dash=True))
+@click.option(
+    "--month", "-m", default="", help="(DEPRECATED: use --period instead) Limit report to month."
+)
+@click.option(
+    "--period",
+    "-p",
+    default="",
+    help="Period description (e.g., 'last month', 'Jan to Mar', 'Jan 2024 to Mar 2024').",
+)
+@click.argument("out-file", type=click.Path(allow_dash=True), default="-")
 @click.pass_context
-def cash_flow_statement(ctx, begin_date, end_date, month, out_file) -> None:
+def cash_flow_statement(ctx, begin_date, end_date, month, period, out_file) -> None:
     """
     Run a cash flow statement for a set time period.
 
-    OUT_FILE is the path to the file to write the tex file.  Use '-' to print
-    to standard output.
+    OUT_FILE is the path to the file to write the tex file. Defaults to standard
+    output if not specified. Use '-' for explicit stdout.
     """
     cash_flow_statement = ctx.obj["cash_flow_statement"]
 
-    if begin_date == end_date == month == "":
-        raise click.UsageError("Please enter a valid begin-date and end-date or a valid month.")
+    if begin_date == end_date == month == period == "":
+        raise click.UsageError("Please enter a valid begin-date and end-date, month, or period.")
+    elif period != "":
+        begin_date, end_date = period_to_dates(period)
     elif month != "":
+        click.echo(
+            "Warning: --month is deprecated. Use --period instead (e.g., --period 'January').",
+            err=True,
+        )
         begin_date, end_date = month_to_dates(month)
 
     report = cash_flow_statement.print_report(begin_date, end_date)

--- a/src/pacioli/income_statement.py
+++ b/src/pacioli/income_statement.py
@@ -57,12 +57,17 @@ class IncomeStatement(Pacioli):
         }
 
         income = self.process_accounts("Income", start_date, end_date)
-        result["income_total"] = income.pop("income_total")
+        result["income_total"] = income.pop("income_total", 0)
         result["income"] = income
 
         expenses = self.process_accounts("Expenses", start_date, end_date)
-        result["expenses_total"] = expenses.pop("expenses_total")
+        result["expenses_total"] = expenses.pop("expenses_total", 0)
         result["expenses"] = expenses
+
+        if result["income_total"] == 0 and not income:
+            logging.warning("No income accounts found for the specified period")
+        if result["expenses_total"] == 0 and not expenses:
+            logging.warning("No expense accounts found for the specified period")
 
         result["net_income"] = result["income_total"] - result["expenses_total"]
 

--- a/src/pacioli/income_statement.py
+++ b/src/pacioli/income_statement.py
@@ -8,8 +8,7 @@ IncomeStatement
 
 import re
 
-from pacioli.pacioli import logging
-from pacioli.pacioli import Pacioli
+from pacioli.pacioli import Pacioli, logging
 from pacioli.utils import format_balance
 
 
@@ -89,9 +88,6 @@ class IncomeStatement(Pacioli):
             Short account names and their balances.
 
         """
-        if self.cleared is not None:
-            cleared = "--cleared"
-
         ledger_command = [
             "ledger",
             "-f",
@@ -102,11 +98,14 @@ class IncomeStatement(Pacioli):
             start_date,
             "-e",
             end_date,
-            self.effective,
             "--depth",
             "2",
         ]
-        if self.cleared is not None:
+
+        if self.effective:
+            ledger_command.append("--effective")
+
+        if self.cleared:
             ledger_command.append("--cleared")
 
         if self.market:

--- a/src/pacioli/pacioli.py
+++ b/src/pacioli/pacioli.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 
 import jinja2
+
 from pacioli.config import Config
 
 

--- a/src/pacioli/utils.py
+++ b/src/pacioli/utils.py
@@ -1,8 +1,166 @@
 import calendar
 import datetime
 import locale
+import re
 
 import click
+
+
+def _parse_month_name(month_name: str) -> int:
+    """Parse a month name (full or abbreviated) to month number.
+
+    Parameters
+    ----------
+    month_name: str
+        Month name or abbreviation
+
+    Returns
+    -------
+    int
+        Month number (1-12)
+
+    Raises
+    ------
+    ValueError
+        If month name is invalid
+    """
+    month_name = month_name.capitalize()
+    try:
+        return list(calendar.month_name).index(month_name)
+    except ValueError:
+        try:
+            return list(calendar.month_abbr).index(month_name)
+        except ValueError:
+            raise ValueError(f"Invalid month name: {month_name}")
+
+
+def period_to_dates(period_str: str) -> list[str]:
+    """Convert a period string to start and end dates in YYYY/MM/DD format.
+
+    Supports various formats:
+    - "last month", "this month"
+    - "Jan 2024 to Mar 2024" (month ranges)
+    - "January 2024" (single month)
+    - "2024/01/15 to 2024/03/31" (explicit date ranges)
+
+    Parameters
+    ----------
+    period_str: str
+        Period description
+
+    Returns
+    -------
+    list[str]
+        [begin_date, end_date] in YYYY/MM/DD format
+    """
+    period_str = period_str.strip()
+    now = datetime.datetime.now()
+
+    # Handle "last month"
+    if period_str.lower() == "last month":
+        if now.month == 1:
+            year = now.year - 1
+            month = 12
+        else:
+            year = now.year
+            month = now.month - 1
+        begin_date = f"{year}/{month}/1"
+        if month == 12:
+            end_date = f"{year+1}/1/1"
+        else:
+            end_date = f"{year}/{month+1}/1"
+        return [begin_date, end_date]
+
+    # Handle "this month"
+    if period_str.lower() == "this month":
+        begin_date = f"{now.year}/{now.month}/1"
+        if now.month == 12:
+            end_date = f"{now.year+1}/1/1"
+        else:
+            end_date = f"{now.year}/{now.month+1}/1"
+        return [begin_date, end_date]
+
+    # Handle "Month to Month" format (defaults to current year)
+    month_range_no_year_pattern = r"^(\w+)\s+to\s+(\w+)$"
+    match = re.match(month_range_no_year_pattern, period_str, re.IGNORECASE)
+    if match:
+        start_month_name, end_month_name = match.groups()
+        try:
+            start_month = _parse_month_name(start_month_name)
+            end_month = _parse_month_name(end_month_name)
+        except ValueError as e:
+            raise click.UsageError(f"Invalid month name in period: {period_str}")
+
+        # Use current year for END date (people typically look backwards)
+        end_year = now.year
+
+        # If end month is before start month, it's a year rollover (e.g., "Dec to Jan")
+        # Start date should be in the previous year
+        if end_month < start_month:
+            start_year = end_year - 1
+        else:
+            start_year = end_year
+
+        begin_date = f"{start_year}/{start_month}/1"
+
+        # End date is first day of month after end_month
+        if end_month == 12:
+            end_date = f"{end_year+1}/1/1"
+        else:
+            end_date = f"{end_year}/{end_month+1}/1"
+        return [begin_date, end_date]
+
+    # Handle "Month YYYY to Month YYYY" format
+    month_range_pattern = r"^(\w+)\s+(\d{4})\s+to\s+(\w+)\s+(\d{4})$"
+    match = re.match(month_range_pattern, period_str, re.IGNORECASE)
+    if match:
+        start_month_name, start_year_str, end_month_name, end_year_str = match.groups()
+        start_year = int(start_year_str)
+        end_year = int(end_year_str)
+        try:
+            start_month = _parse_month_name(start_month_name)
+            end_month = _parse_month_name(end_month_name)
+        except ValueError:
+            raise click.UsageError(f"Invalid month name in period: {period_str}")
+
+        begin_date = f"{start_year}/{start_month}/1"
+        # End date is first day of month after end_month
+        if end_month == 12:
+            end_date = f"{end_year+1}/1/1"
+        else:
+            end_date = f"{end_year}/{end_month+1}/1"
+        return [begin_date, end_date]
+
+    # Handle "Month YYYY" format (single month)
+    single_month_pattern = r"^(\w+)\s+(\d{4})$"
+    match = re.match(single_month_pattern, period_str, re.IGNORECASE)
+    if match:
+        month_name, year_str = match.groups()
+        year = int(year_str)
+        try:
+            month = _parse_month_name(month_name)
+        except ValueError:
+            raise click.UsageError(f"Invalid month name: {month_name}")
+
+        begin_date = f"{year}/{month}/1"
+        if month == 12:
+            end_date = f"{year+1}/1/1"
+        else:
+            end_date = f"{year}/{month+1}/1"
+        return [begin_date, end_date]
+
+    # Handle explicit date range "YYYY/MM/DD to YYYY/MM/DD"
+    date_range_pattern = r"^(\d{4}/\d{1,2}/\d{1,2})\s+to\s+(\d{4}/\d{1,2}/\d{1,2})$"
+    match = re.match(date_range_pattern, period_str)
+    if match:
+        begin_date, end_date = match.groups()
+        return [begin_date, end_date]
+
+    raise click.UsageError(
+        f"Invalid period format: '{period_str}'. "
+        "Supported formats: 'last month', 'this month', 'Jan to Mar', "
+        "'Jan 2024 to Mar 2024', 'January 2024', or 'YYYY/MM/DD to YYYY/MM/DD'"
+    )
 
 
 def month_to_dates(month_str: str) -> list[str]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Test the Config Class."""
 
 import pytest
+
 from pacioli.config import Config
 
 

--- a/tests/test_pacioli.py
+++ b/tests/test_pacioli.py
@@ -4,10 +4,10 @@ import locale
 import subprocess
 
 import pytest
+
 from pacioli import __version__
 from pacioli.pacioli import Pacioli
-from pacioli.utils import format_balance
-from pacioli.utils import format_negative_numbers
+from pacioli.utils import format_balance, format_negative_numbers
 
 
 def test_version():

--- a/tests/test_pacioli.py
+++ b/tests/test_pacioli.py
@@ -12,7 +12,7 @@ from pacioli.utils import format_balance, format_negative_numbers
 
 def test_version():
     """Tests the version number."""
-    assert __version__ == "1.1.0"
+    assert __version__ == "1.2.0"
 
 
 def test_ledger_available():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,11 +2,17 @@
 
 import datetime
 import locale
+from unittest.mock import patch
 
 import pytest
-from pacioli.utils import format_balance
-from pacioli.utils import format_negative_numbers
-from pacioli.utils import month_to_dates
+from click.exceptions import UsageError
+
+from pacioli.utils import (
+    format_balance,
+    format_negative_numbers,
+    month_to_dates,
+    period_to_dates,
+)
 
 
 def test_month_to_dates() -> None:
@@ -70,3 +76,182 @@ def test_format_negative_numbers_returns_negative_number_in_parentheses():
 def test_month_to_dates_uses_date_format() -> None:
     """Test use of date format from config file."""
     assert False
+
+
+def test_period_to_dates_last_month() -> None:
+    """Test 'last month' period string."""
+    now = datetime.datetime.now()
+    if now.month == 1:
+        expected_year = now.year - 1
+        expected_month = 12
+    else:
+        expected_year = now.year
+        expected_month = now.month - 1
+
+    begin_date = f"{expected_year}/{expected_month}/1"
+    if expected_month == 12:
+        end_date = f"{expected_year+1}/1/1"
+    else:
+        end_date = f"{expected_year}/{expected_month+1}/1"
+
+    result = period_to_dates("last month")
+    assert result == [begin_date, end_date]
+
+
+def test_period_to_dates_this_month() -> None:
+    """Test 'this month' period string."""
+    now = datetime.datetime.now()
+    begin_date = f"{now.year}/{now.month}/1"
+    if now.month == 12:
+        end_date = f"{now.year+1}/1/1"
+    else:
+        end_date = f"{now.year}/{now.month+1}/1"
+
+    result = period_to_dates("this month")
+    assert result == [begin_date, end_date]
+
+
+def test_period_to_dates_month_range() -> None:
+    """Test month range format like 'Jan 2024 to Mar 2024'."""
+    result = period_to_dates("Jan 2024 to Mar 2024")
+    assert result == ["2024/1/1", "2024/4/1"]
+
+
+def test_period_to_dates_month_range_full_names() -> None:
+    """Test month range with full month names."""
+    result = period_to_dates("January 2024 to March 2024")
+    assert result == ["2024/1/1", "2024/4/1"]
+
+
+def test_period_to_dates_month_range_december() -> None:
+    """Test month range ending in December rolls over year."""
+    result = period_to_dates("Oct 2024 to Dec 2024")
+    assert result == ["2024/10/1", "2025/1/1"]
+
+
+def test_period_to_dates_single_month() -> None:
+    """Test single month format like 'January 2024'."""
+    result = period_to_dates("January 2024")
+    assert result == ["2024/1/1", "2024/2/1"]
+
+
+def test_period_to_dates_single_month_abbreviated() -> None:
+    """Test single month with abbreviated name."""
+    result = period_to_dates("Jan 2024")
+    assert result == ["2024/1/1", "2024/2/1"]
+
+
+def test_period_to_dates_single_month_december() -> None:
+    """Test single month December rolls over year."""
+    result = period_to_dates("December 2024")
+    assert result == ["2024/12/1", "2025/1/1"]
+
+
+def test_period_to_dates_explicit_date_range() -> None:
+    """Test explicit date range format."""
+    result = period_to_dates("2024/1/15 to 2024/3/31")
+    assert result == ["2024/1/15", "2024/3/31"]
+
+
+def test_period_to_dates_invalid_format() -> None:
+    """Test that invalid format raises UsageError."""
+    with pytest.raises(UsageError):
+        period_to_dates("invalid period")
+
+
+def test_period_to_dates_invalid_month_name() -> None:
+    """Test that invalid month name raises UsageError."""
+    with pytest.raises(UsageError):
+        period_to_dates("Foo 2024 to Bar 2024")
+
+
+def test_period_to_dates_month_range_no_year() -> None:
+    """Test 'Jan to Mar' format (same year, no rollover)."""
+    now = datetime.datetime.now()
+    result = period_to_dates("Jan to Mar")
+    # Should use current year for both
+    assert result == [f"{now.year}/1/1", f"{now.year}/4/1"]
+
+
+def test_period_to_dates_month_range_no_year_rollover() -> None:
+    """Test 'Dec to January' format (year rollover)."""
+    now = datetime.datetime.now()
+    result = period_to_dates("Dec to January")
+    # Should use previous year for start, current year for end
+    assert result == [f"{now.year-1}/12/1", f"{now.year}/2/1"]
+
+
+def test_period_to_dates_month_range_no_year_rollover_full_names() -> None:
+    """Test 'November to February' format (year rollover with full names)."""
+    now = datetime.datetime.now()
+    result = period_to_dates("November to February")
+    # Should use previous year for start, current year for end
+    assert result == [f"{now.year-1}/11/1", f"{now.year}/3/1"]
+
+
+def test_period_to_dates_month_range_no_year_mixed() -> None:
+    """Test mixed abbreviations and full names."""
+    now = datetime.datetime.now()
+    result = period_to_dates("Oct to March")
+    # Year rollover: Oct is after March, so Oct is previous year
+    assert result == [f"{now.year-1}/10/1", f"{now.year}/4/1"]
+
+
+def test_period_to_dates_month_range_no_year_december() -> None:
+    """Test month range ending in December without year (e.g., 'Jan to Dec')."""
+    now = datetime.datetime.now()
+    result = period_to_dates("Jan to Dec")
+    assert result == [f"{now.year}/1/1", f"{now.year+1}/1/1"]
+
+
+def test_period_to_dates_month_range_no_year_invalid_month() -> None:
+    """Test invalid month name in month range without year raises UsageError."""
+    with pytest.raises(UsageError):
+        period_to_dates("Foo to Bar")
+
+
+def test_period_to_dates_single_month_invalid_name() -> None:
+    """Test invalid month name in single month format raises UsageError."""
+    with pytest.raises(UsageError):
+        period_to_dates("Foo 2024")
+
+
+@patch("pacioli.utils.datetime")
+def test_period_to_dates_last_month_january(mock_datetime) -> None:
+    """Test 'last month' when current month is January."""
+    mock_datetime.datetime.now.return_value = datetime.datetime(2024, 1, 15)
+    result = period_to_dates("last month")
+    assert result == ["2023/12/1", "2024/1/1"]
+
+
+@patch("pacioli.utils.datetime")
+def test_period_to_dates_last_month_non_january(mock_datetime) -> None:
+    """Test 'last month' when current month is not January."""
+    mock_datetime.datetime.now.return_value = datetime.datetime(2024, 5, 15)
+    result = period_to_dates("last month")
+    assert result == ["2024/4/1", "2024/5/1"]
+
+
+@patch("pacioli.utils.datetime")
+def test_period_to_dates_last_month_december_rollover(mock_datetime) -> None:
+    """Test 'last month' when last month was December (current month is January)."""
+    mock_datetime.datetime.now.return_value = datetime.datetime(2024, 2, 15)
+    result = period_to_dates("last month")
+    # Last month was January, so it should be Jan 1 to Feb 1
+    assert result == ["2024/1/1", "2024/2/1"]
+
+
+@patch("pacioli.utils.datetime")
+def test_period_to_dates_this_month_december(mock_datetime) -> None:
+    """Test 'this month' when current month is December."""
+    mock_datetime.datetime.now.return_value = datetime.datetime(2024, 12, 15)
+    result = period_to_dates("this month")
+    assert result == ["2024/12/1", "2025/1/1"]
+
+
+@patch("pacioli.utils.datetime")
+def test_period_to_dates_this_month_non_december(mock_datetime) -> None:
+    """Test 'this month' when current month is not December."""
+    mock_datetime.datetime.now.return_value = datetime.datetime(2024, 5, 15)
+    result = period_to_dates("this month")
+    assert result == ["2024/5/1", "2024/6/1"]


### PR DESCRIPTION
## Summary

- Add new `--period` option for income-statement and cash-flow-statement commands with natural language support
- Deprecate the existing `--month` option in favor of `--period`
- Make OUT_FILE argument default to stdout for all report commands
- Update pre-commit hooks to use local/system Python to avoid venv issues

## New Period Format Support

The `--period` option supports multiple natural language formats:
- `last month`, `this month`
- `Jan to Mar` (month ranges without year, handles year rollovers)
- `Jan 2024 to Mar 2024` (month ranges with explicit years)
- `January 2024` (single month with year)
- `2024/01/15 to 2024/03/31` (explicit date ranges)

## Additional Changes

- Updated man page documentation with period examples
- Added new dependencies: isort, pyupgrade, pre-commit-hooks
- Code quality improvements: optimized imports, updated type hints to use Python 3.10+ syntax
- Updated tests to reflect new default behavior and period functionality
- Bumped version to 1.2.0

## Test plan

- [x] Verify `--period "last month"` generates correct date range
- [x] Test month range without year (e.g., `Jan to Mar`)
- [x] Test year rollover handling (e.g., `Dec to January`)
- [x] Confirm `--month` shows deprecation warning but still works
- [x] Verify OUT_FILE defaults to stdout when not specified
- [x] Run full test suite to ensure all existing functionality works